### PR TITLE
Bug fix in `ggcoef_compare()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggstats (development version)
 
+* Bug fix in `ggcoef_compare()` to preserve the order of model terms and to 
+  avoid an erreor with `add_reference_rows = FALSE` (#23)
+
 # ggstats 0.2.1
 
 * Bug fix in `geom_stripped_rows()` and `geom_stripped_cols()` (#20)

--- a/R/ggcoef_model.R
+++ b/R/ggcoef_model.R
@@ -331,6 +331,10 @@ ggcoef_compare <- function(
   coefficients_label <- attr(data, "coefficients_label")
 
   data$model <- .in_order(data$model)
+  data$term <- .in_order(data$term)
+  data$var_label <- .in_order(data$var_label)
+  data$variable <- .in_order(data$variable)
+  data$label <- .in_order(data$label)
 
   # include should be applied after lapply
   data <- data %>%
@@ -347,10 +351,12 @@ ggcoef_compare <- function(
       .data$model,
       tidyr::nesting(
         !!sym("var_label"), !!sym("variable"), !!sym("var_class"),
-        !!sym("var_type"), !!sym("contrasts"), !!sym("reference_row"),
-        !!sym("label"), !!sym("label_light")
+        !!sym("var_type"), !!sym("contrasts"),
+        !!sym("label"), !!sym("label_light"), !!sym("term")
       )
-    )
+    ) %>%
+    # order lost after nesting
+    dplyr::arrange(.data$model, .data$variable, .data$term)
 
   attr(data, "coefficients_label") <- coefficients_label
 
@@ -583,6 +589,7 @@ ggcoef_data <- function(
   # keep only rows with estimate
   data <- data[!is.na(data$estimate), ]
 
+  data$term <- .in_order(data$term)
   data$var_label <- .in_order(data$var_label)
   data$variable <- .in_order(data$variable)
   data$label <- .in_order(data$label)


### PR DESCRIPTION
to preserve the order of model terms and to  avoid an erreor with `add_reference_rows = FALSE`

fix #23