### PR TITLE
`gglikert()`: legend order is reversed when `reverse_likert = TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ggstats (development version)
 
+**Improvements**
+
+* `gglikert()`: legend order is reversed when `reverse_likert = TRUE` (#95)
+* `gglikert_stacked()`: legend order is reversed when `reverse_fill = TRUE`
+  (#95)
+
 # ggstats 0.9.0
 
 **Improvements**

--- a/R/gglikert.R
+++ b/R/gglikert.R
@@ -395,7 +395,8 @@ gglikert <- function(data,
       legend.position = "bottom",
       panel.grid.major.y = element_blank()
     ) +
-    scale_fill_likert(cutoff = cutoff)
+    scale_fill_likert(cutoff = cutoff) +
+    guides(fill = guide_legend(reverse = reverse_likert))
 
   p + facet_grid(
     rows = facet_rows, cols = facet_cols,
@@ -774,7 +775,8 @@ gglikert_stacked <- function(data,
       legend.position = "bottom",
       panel.grid.major.y = element_blank()
     ) +
-    scale_fill_extended()
+    scale_fill_extended() +
+    guides(fill = guide_legend(reverse = !reverse_fill))
 
   p
 }


### PR DESCRIPTION
fix #95