### PR TITLE
Remove `dim` attribute before calling `bind_rows()`

### DIFF
--- a/R/geom_connector.R
+++ b/R/geom_connector.R
@@ -239,7 +239,7 @@ connect_points <- function(data, width = 0.9, continuous = FALSE) {
     dplyr::select(-dplyr::all_of(c("..rank..", "..order..")))
 }
 
-undim <- function (x) {
+undim <- function(x) {
   dim <- dim(x)
 
   if (is.null(dim)) {

--- a/R/weighted_quantile.R
+++ b/R/weighted_quantile.R
@@ -104,5 +104,5 @@ weighted.quantile <- function(x, w, probs = seq(0, 1, 0.25),
     format(100 * probs, trim = TRUE),
     "%"
   )
-  return(result)
+  result
 }

--- a/tests/testthat/test-ggcoef_model.R
+++ b/tests/testthat/test-ggcoef_model.R
@@ -27,7 +27,7 @@ test_that("ggcoef_model()", {
   # custom variable labels
   # you can use to define variable labels before computing model
   if (requireNamespace("labelled")) {
-    tips_labelled <- tips %>%
+    tips_labelled <- tips |>
       labelled::set_variable_labels(
         day = "Day of the week",
         time = "Lunch or Dinner",
@@ -273,8 +273,8 @@ test_that("ggcoef_model() works with tieders not returning p-values", {
 
   mod <- lm(Sepal.Width ~ Species, iris)
   my_tidier <- function(x, ...) {
-    x %>%
-      broom::tidy(...) %>%
+    x |>
+      broom::tidy(...) |>
       dplyr::select(-dplyr::all_of("p.value"))
   }
   vdiffr::expect_doppelganger(
@@ -346,7 +346,7 @@ test_that("ggcoef_model() works with pairwise contratst", {
 test_that("tidy_args is supported", {
   mod <- lm(Sepal.Length ~ Sepal.Width, data = iris)
   custom <- function(x, force = 1, ...) {
-    broom::tidy(x, ...) %>%
+    broom::tidy(x, ...) |>
       dplyr::mutate(estimate = force)
   }
   res <- ggcoef_model(

--- a/tests/testthat/test-gglikert.R
+++ b/tests/testthat/test-gglikert.R
@@ -20,7 +20,7 @@ test_that("gglikert()", {
       q4 = sample(likert_levels, 150, replace = TRUE, prob = 1:5),
       q5 = sample(c(likert_levels, NA), 150, replace = TRUE),
       q6 = sample(likert_levels, 150, replace = TRUE, prob = c(1, 0, 1, 1, 0))
-    ) %>%
+    ) |>
     dplyr::mutate(dplyr::across(
       dplyr::everything(),
       ~ factor(.x, levels = likert_levels)
@@ -45,7 +45,7 @@ test_that("gglikert()", {
         likert_levels_dk, 150,
         replace = TRUE, prob = c(1, 0, 1, 1, 0, 1)
       )
-    ) %>%
+    ) |>
     dplyr::mutate(dplyr::across(
       dplyr::everything(),
       ~ factor(.x, levels = likert_levels_dk)
@@ -159,12 +159,12 @@ test_that("gglikert()", {
 
   vdiffr::expect_doppelganger(
     "gglikert() variable labels and y_label_wrap",
-    df %>%
+    df |>
       labelled::set_variable_labels(
         q1 = "first question",
         q2 = "second question",
         q3 = "third question with a very very very veru very very long label"
-      ) %>%
+      ) |>
       gglikert(
         variable_labels = c(
           q2 = "question 2",

--- a/tests/testthat/test-stat_cross.R
+++ b/tests/testthat/test-stat_cross.R
@@ -57,11 +57,11 @@ test_that("stat_cross()", {
 })
 
 test_that("phi coefficients", {
-  res <- Titanic %>%
-    as.data.frame() %>%
-    xtabs(Freq ~ Sex + Class, data = .) %>%
-    chisq.test() %>%
-    augment_chisq_add_phi() %>%
+  res <- Titanic |>
+    as.data.frame() |>
+    xtabs(Freq ~ Sex + Class, data = _) |>
+    chisq.test() |>
+    augment_chisq_add_phi() |>
     dplyr::mutate(.phi = round(.data$.phi, digits = 3))
   expect_equal(
     res$.phi,


### PR DESCRIPTION
We are working on the next vctrs release, targeted for Jan 15, and this package came up in our revdep analysis.

`vctrs::obj_is_list()` no longer returns `TRUE` for _list arrays_, which means that you can't pass a list array to things like `dplyr::bind_rows()`. Unfortunately `by()` returns one of these, so you must undim the result first.